### PR TITLE
Fix notices reported by the Tuleap test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ matrix:
   include:
     - php: "7.2"
     - php: "7.3"
+    - php: "7.4snapshot"
 
 script:
  - 'vendor/bin/phpunit'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false" colors="true" bootstrap="./test/bootstrap.php">
+	<php>
+		<ini name="error_reporting" value="24575" /> <!-- Removing deprecation notice from the reporting, remaining notice is due to the outdated version of PHPUnit  -->
+	</php>
 	<testsuite name="Mustache">
 		<directory suffix="Test.php">./test</directory>
 		<exclude>./test/Mustache/Test/FiveThree</exclude>

--- a/src/Mustache/Parser.php
+++ b/src/Mustache/Parser.php
@@ -149,7 +149,7 @@ class Mustache_Parser
                 case Mustache_Tokenizer::T_BLOCK_VAR:
                     if ($this->pragmaBlocks) {
                         // BLOCKS pragma is enabled, let's do this!
-                        if ($parent[Mustache_Tokenizer::TYPE] === Mustache_Tokenizer::T_PARENT) {
+                        if ($parent !== null && $parent[Mustache_Tokenizer::TYPE] === Mustache_Tokenizer::T_PARENT) {
                             $token[Mustache_Tokenizer::TYPE] = Mustache_Tokenizer::T_BLOCK_ARG;
                         }
                         $this->clearStandaloneLines($nodes, $tokens);
@@ -275,7 +275,7 @@ class Mustache_Parser
      */
     private function checkIfTokenIsAllowedInParent($parent, array $token)
     {
-        if ($parent[Mustache_Tokenizer::TYPE] === Mustache_Tokenizer::T_PARENT) {
+        if ($parent !== null && $parent[Mustache_Tokenizer::TYPE] === Mustache_Tokenizer::T_PARENT) {
             throw new Mustache_Exception_SyntaxException('Illegal content in < parent tag', $token);
         }
     }


### PR DESCRIPTION
Since PHP 7.4 beta 1, PHP complains with a notice for
invalid array accesses.

Related to request #13487: Run Tuleap test suites with PHP 7.4