### PR TITLE
Bump to PHPUnit 8.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 mustache.php
 vendor
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,10 @@
         }
     ],
     "require": {
-        "php": ">=5.2.4"
+        "php": ">=7.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "~3.7|~4.0|~5.0",
-        "friendsofphp/php-cs-fixer": "~1.11"
+        "phpunit/phpunit": "^8.3"
     },
     "autoload": {
         "psr-0": { "Mustache": "src/" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false" colors="true" bootstrap="./test/bootstrap.php">
-	<php>
-		<ini name="error_reporting" value="24575" /> <!-- Removing deprecation notice from the reporting, remaining notice is due to the outdated version of PHPUnit  -->
-	</php>
-	<testsuite name="Mustache">
-		<directory suffix="Test.php">./test</directory>
-		<exclude>./test/Mustache/Test/FiveThree</exclude>
-	</testsuite>
+	<testsuites>
+		<testsuite name="Mustache">
+			<directory suffix="Test.php">./test</directory>
+			<exclude>./test/Mustache/Test/FiveThree</exclude>
+		</testsuite>
 
-	<testsuite name="Mustache FiveThree">
-		<directory suffix="Test.php" phpVersion="5.3.0" phpVersionOperator=">=">./test/Mustache/Test/FiveThree</directory>
-	</testsuite>
+		<testsuite name="Mustache FiveThree">
+			<directory suffix="Test.php" phpVersion="5.3.0" phpVersionOperator=">=">./test/Mustache/Test/FiveThree</directory>
+		</testsuite>
+	</testsuites>
 
 	<filter>
 		<whitelist>

--- a/test/Mustache/Test/AutoloaderTest.php
+++ b/test/Mustache/Test/AutoloaderTest.php
@@ -9,10 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group unit
  */
-class Mustache_Test_AutoloaderTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_AutoloaderTest extends TestCase
 {
     public function testRegister()
     {

--- a/test/Mustache/Test/Cache/AbstractCacheTest.php
+++ b/test/Mustache/Test/Cache/AbstractCacheTest.php
@@ -9,7 +9,9 @@
  * file that was distributed with this source code.
  */
 
-class Mustache_Test_Cache_AbstractCacheTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Mustache_Test_Cache_AbstractCacheTest extends TestCase
 {
     public function testGetSetLogger()
     {
@@ -19,13 +21,11 @@ class Mustache_Test_Cache_AbstractCacheTest extends PHPUnit_Framework_TestCase
         $this->assertSame($logger, $cache->getLogger());
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testSetLoggerThrowsExceptions()
     {
         $cache  = new CacheStub();
         $logger = new StdClass();
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         $cache->setLogger($logger);
     }
 }

--- a/test/Mustache/Test/CompilerTest.php
+++ b/test/Mustache/Test/CompilerTest.php
@@ -9,10 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group unit
  */
-class Mustache_Test_CompilerTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_CompilerTest extends TestCase
 {
     /**
      * @dataProvider getCompileValues
@@ -23,7 +25,7 @@ class Mustache_Test_CompilerTest extends PHPUnit_Framework_TestCase
 
         $compiled = $compiler->compile($source, $tree, $name, $customEscaper, $charset, false, $entityFlags, false);
         foreach ($expected as $contains) {
-            $this->assertContains($contains, $compiled);
+            $this->assertStringContainsString($contains, $compiled);
         }
     }
 
@@ -132,12 +134,10 @@ class Mustache_Test_CompilerTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Mustache_Exception_SyntaxException
-     */
     public function testCompilerThrowsSyntaxException()
     {
         $compiler = new Mustache_Compiler();
+        $this->expectException(Mustache_Exception_SyntaxException::class);
         $compiler->compile('', array(array(Mustache_Tokenizer::TYPE => 'invalid')), 'SomeClass');
     }
 

--- a/test/Mustache/Test/ContextTest.php
+++ b/test/Mustache/Test/ContextTest.php
@@ -9,10 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group unit
  */
-class Mustache_Test_ContextTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_ContextTest extends TestCase
 {
     public function testConstructor()
     {
@@ -171,29 +173,22 @@ class Mustache_Test_ContextTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $context->findAnchoredDot('.child.name'));
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testAnchoredDotNotationThrowsExceptions()
     {
         $context = new Mustache_Context();
         $context->push(array('a' => 1));
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         $context->findAnchoredDot('a');
     }
 
-    /**
-     * @expectedException Mustache_Exception_UnknownVariableException
-     */
     public function testUnknownVariableThrowsException()
     {
         $context = new Mustache_Context(null, true);
         $context->push(array('a' => 1));
+        $this->expectException(Mustache_Exception_UnknownVariableException::class);
         $context->find('b');
     }
 
-    /**
-     * @expectedException Mustache_Exception_UnknownVariableException
-     */
     public function testAnchoredDotNotationUnknownVariableThrowsException()
     {
         $context = new Mustache_Context(null, true);
@@ -201,6 +196,7 @@ class Mustache_Test_ContextTest extends PHPUnit_Framework_TestCase
             'a' => array('b' => 1),
         );
         $context->push($a);
+        $this->expectException(Mustache_Exception_UnknownVariableException::class);
         $context->find('a.c');
     }
 }

--- a/test/Mustache/Test/EngineTest.php
+++ b/test/Mustache/Test/EngineTest.php
@@ -43,7 +43,7 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
         $this->assertSame($loader, $mustache->getLoader());
         $this->assertSame($partialsLoader, $mustache->getPartialsLoader());
         $this->assertEquals('{{ foo }}', $partialsLoader->load('foo'));
-        $this->assertContains('__whot__', $mustache->getTemplateClassName('{{ foo }}'));
+        $this->assertStringContainsString('__whot__', $mustache->getTemplateClassName('{{ foo }}'));
         $this->assertEquals('strtoupper', $mustache->getEscape());
         $this->assertEquals(ENT_QUOTES, $mustache->getEntityFlags());
         $this->assertEquals('ISO-8859-1', $mustache->getCharset());
@@ -158,22 +158,20 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
         $this->assertNotSame($mustache->getCache(), $mustache->getProtectedLambdaCache());
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testEmptyTemplatePrefixThrowsException()
     {
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         new Mustache_Engine(array(
             'template_class_prefix' => '',
         ));
     }
 
     /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
      * @dataProvider getBadEscapers
      */
     public function testNonCallableEscapeThrowsException($escape)
     {
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         new Mustache_Engine(array('escape' => $escape));
     }
 
@@ -185,15 +183,13 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
         );
     }
 
-    /**
-     * @expectedException Mustache_Exception_RuntimeException
-     */
     public function testImmutablePartialsLoadersThrowException()
     {
         $mustache = new Mustache_Engine(array(
             'partials_loader' => new Mustache_Loader_StringLoader(),
         ));
 
+        $this->expectException(Mustache_Exception_RuntimeException::class);
         $mustache->setPartials(array('foo' => '{{ foo }}'));
     }
 
@@ -250,21 +246,17 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
         return '__' . $text . '__';
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testSetHelpersThrowsExceptions()
     {
         $mustache = new Mustache_Engine();
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         $mustache->setHelpers('monkeymonkeymonkey');
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testSetLoggerThrowsExceptions()
     {
         $mustache = new Mustache_Engine();
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         $mustache->setLogger(new StdClass());
     }
 
@@ -305,14 +297,14 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
         $result = $mustache->render('{{> foo }}{{> bar }}{{> baz }}', array());
         $this->assertEquals('FOOBAR', $result);
 
-        $this->assertContains('WARNING: Partial not found: "baz"', file_get_contents($name));
+        $this->assertStringContainsString('WARNING: Partial not found: "baz"', file_get_contents($name));
     }
 
     public function testCacheWarningLogging()
     {
         list($name, $mustache) = $this->getLoggedMustache(Mustache_Logger::WARNING);
         $mustache->render('{{ foo }}', array('foo' => 'FOO'));
-        $this->assertContains('WARNING: Template cache disabled, evaluating', file_get_contents($name));
+        $this->assertStringContainsString('WARNING: Template cache disabled, evaluating', file_get_contents($name));
     }
 
     public function testLoggingIsNotTooAnnoying()
@@ -327,15 +319,13 @@ class Mustache_Test_EngineTest extends Mustache_Test_FunctionalTestCase
         list($name, $mustache) = $this->getLoggedMustache(Mustache_Logger::DEBUG);
         $mustache->render('{{ foo }}{{> bar }}', array('foo' => 'FOO'));
         $log = file_get_contents($name);
-        $this->assertContains('DEBUG: Instantiating template: ', $log);
-        $this->assertContains('WARNING: Partial not found: "bar"', $log);
+        $this->assertStringContainsString('DEBUG: Instantiating template: ', $log);
+        $this->assertStringContainsString('WARNING: Partial not found: "bar"', $log);
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testUnknownPragmaThrowsException()
     {
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         new Mustache_Engine(array(
             'pragmas' => array('UNKNOWN'),
         ));

--- a/test/Mustache/Test/Exception/SyntaxExceptionTest.php
+++ b/test/Mustache/Test/Exception/SyntaxExceptionTest.php
@@ -9,7 +9,9 @@
  * file that was distributed with this source code.
  */
 
-class Mustache_Test_Exception_SyntaxExceptionTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Mustache_Test_Exception_SyntaxExceptionTest extends TestCase
 {
     public function testInstance()
     {

--- a/test/Mustache/Test/Exception/UnknownFilterExceptionTest.php
+++ b/test/Mustache/Test/Exception/UnknownFilterExceptionTest.php
@@ -9,7 +9,9 @@
  * file that was distributed with this source code.
  */
 
-class Mustache_Test_Exception_UnknownFilterExceptionTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Mustache_Test_Exception_UnknownFilterExceptionTest extends TestCase
 {
     public function testInstance()
     {

--- a/test/Mustache/Test/Exception/UnknownHelperExceptionTest.php
+++ b/test/Mustache/Test/Exception/UnknownHelperExceptionTest.php
@@ -9,7 +9,9 @@
  * file that was distributed with this source code.
  */
 
-class Mustache_Test_Exception_UnknownHelperExceptionTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Mustache_Test_Exception_UnknownHelperExceptionTest extends TestCase
 {
     public function testInstance()
     {

--- a/test/Mustache/Test/Exception/UnknownTemplateExceptionTest.php
+++ b/test/Mustache/Test/Exception/UnknownTemplateExceptionTest.php
@@ -9,7 +9,9 @@
  * file that was distributed with this source code.
  */
 
-class Mustache_Test_Exception_UnknownTemplateExceptionTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Mustache_Test_Exception_UnknownTemplateExceptionTest extends TestCase
 {
     public function testInstance()
     {

--- a/test/Mustache/Test/Exception/UnknownVariableExceptionTest.php
+++ b/test/Mustache/Test/Exception/UnknownVariableExceptionTest.php
@@ -9,7 +9,9 @@
  * file that was distributed with this source code.
  */
 
-class Mustache_Test_Exception_UnknownVariableExceptionTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Mustache_Test_Exception_UnknownVariableExceptionTest extends TestCase
 {
 
     public function testInstance()

--- a/test/Mustache/Test/FiveThree/Functional/ClosureQuirksTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/ClosureQuirksTest.php
@@ -9,15 +9,17 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group lambdas
  * @group functional
  */
-class Mustache_Test_FiveThree_Functional_ClosureQuirksTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_FiveThree_Functional_ClosureQuirksTest extends TestCase
 {
     private $mustache;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->mustache = new Mustache_Engine();
     }

--- a/test/Mustache/Test/FiveThree/Functional/EngineTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/EngineTest.php
@@ -9,11 +9,13 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group pragmas
  * @group functional
  */
-class Mustache_Test_FiveThree_Functional_EngineTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_FiveThree_Functional_EngineTest extends TestCase
 {
     /**
      * @dataProvider pragmaData

--- a/test/Mustache/Test/FiveThree/Functional/FiltersTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/FiltersTest.php
@@ -9,15 +9,17 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group filters
  * @group functional
  */
-class Mustache_Test_FiveThree_Functional_FiltersTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_FiveThree_Functional_FiltersTest extends TestCase
 {
     private $mustache;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->mustache = new Mustache_Engine();
     }
@@ -128,11 +130,11 @@ EOS;
     }
 
     /**
-     * @expectedException Mustache_Exception_UnknownFilterException
      * @dataProvider brokenPipeData
      */
     public function testThrowsExceptionForBrokenPipes($tpl, $data)
     {
+        $this->expectException(Mustache_Exception_UnknownFilterException::class);
         $this->mustache->render($tpl, $data);
     }
 

--- a/test/Mustache/Test/FiveThree/Functional/HigherOrderSectionsTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/HigherOrderSectionsTest.php
@@ -9,15 +9,17 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group lambdas
  * @group functional
  */
-class Mustache_Test_FiveThree_Functional_HigherOrderSectionsTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_FiveThree_Functional_HigherOrderSectionsTest extends TestCase
 {
     private $mustache;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->mustache = new Mustache_Engine();
     }

--- a/test/Mustache/Test/FiveThree/Functional/LambdaHelperTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/LambdaHelperTest.php
@@ -9,15 +9,17 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group lambdas
  * @group functional
  */
-class Mustache_Test_FiveThree_Functional_LambdaHelperTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_FiveThree_Functional_LambdaHelperTest extends TestCase
 {
     private $mustache;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->mustache = new Mustache_Engine();
     }

--- a/test/Mustache/Test/FiveThree/Functional/MustacheSpecTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/MustacheSpecTest.php
@@ -23,6 +23,7 @@ class Mustache_Test_FiveThree_Functional_MustacheSpecTest extends Mustache_Test_
      */
     public function testSpecInitialized()
     {
+        $this->expectNotToPerformAssertions();
         if (!file_exists(dirname(__FILE__) . '/../../../../../vendor/spec/specs/')) {
             $this->markTestSkipped('Mustache spec submodule not initialized: run "git submodule update --init"');
         }

--- a/test/Mustache/Test/FiveThree/Functional/PartialLambdaIndentTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/PartialLambdaIndentTest.php
@@ -9,11 +9,13 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group lambdas
  * @group functional
  */
-class Mustache_Test_FiveThree_Functional_PartialLambdaIndentTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_FiveThree_Functional_PartialLambdaIndentTest extends TestCase
 {
     public function testLambdasInsidePartialsAreIndentedProperly()
     {

--- a/test/Mustache/Test/FiveThree/Functional/StrictCallablesTest.php
+++ b/test/Mustache/Test/FiveThree/Functional/StrictCallablesTest.php
@@ -9,11 +9,13 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group lambdas
  * @group functional
  */
-class Mustache_Test_FiveThree_Functional_StrictCallablesTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_FiveThree_Functional_StrictCallablesTest extends TestCase
 {
     /**
      * @dataProvider callables

--- a/test/Mustache/Test/Functional/CallTest.php
+++ b/test/Mustache/Test/Functional/CallTest.php
@@ -9,11 +9,13 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group magic_methods
  * @group functional
  */
-class Mustache_Test_Functional_CallTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Functional_CallTest extends TestCase
 {
     public function testCallEatsContext()
     {

--- a/test/Mustache/Test/Functional/ExamplesTest.php
+++ b/test/Mustache/Test/Functional/ExamplesTest.php
@@ -9,11 +9,13 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group examples
  * @group functional
  */
-class Mustache_Test_Functional_ExamplesTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Functional_ExamplesTest extends TestCase
 {
     /**
      * Test everything in the `examples` directory.

--- a/test/Mustache/Test/Functional/HigherOrderSectionsTest.php
+++ b/test/Mustache/Test/Functional/HigherOrderSectionsTest.php
@@ -17,7 +17,7 @@ class Mustache_Test_Functional_HigherOrderSectionsTest extends Mustache_Test_Fun
 {
     private $mustache;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->mustache = new Mustache_Engine();
     }

--- a/test/Mustache/Test/Functional/InheritanceTest.php
+++ b/test/Mustache/Test/Functional/InheritanceTest.php
@@ -9,15 +9,17 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group inheritance
  * @group functional
  */
-class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Functional_InheritanceTest extends TestCase
 {
     private $mustache;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->mustache = new Mustache_Engine(array(
             'pragmas' => array(Mustache_Engine::PRAGMA_BLOCKS),
@@ -521,12 +523,12 @@ class Mustache_Test_Functional_InheritanceTest extends PHPUnit_Framework_TestCas
 
     /**
      * @dataProvider getIllegalInheritanceExamples
-     * @expectedException Mustache_Exception_SyntaxException
-     * @expectedExceptionMessage Illegal content in < parent tag
      */
     public function testIllegalInheritanceExamples($partials, $data, $template)
     {
         $this->mustache->setPartials($partials);
+        $this->expectException(Mustache_Exception_SyntaxException::class);
+        $this->expectExceptionMessage('Illegal content in < parent tag');
         $tpl = $this->mustache->loadTemplate($template);
         $tpl->render($data);
     }

--- a/test/Mustache/Test/Functional/MustacheInjectionTest.php
+++ b/test/Mustache/Test/Functional/MustacheInjectionTest.php
@@ -9,15 +9,17 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group mustache_injection
  * @group functional
  */
-class Mustache_Test_Functional_MustacheInjectionTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Functional_MustacheInjectionTest extends TestCase
 {
     private $mustache;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->mustache = new Mustache_Engine();
     }

--- a/test/Mustache/Test/Functional/MustacheSpecTest.php
+++ b/test/Mustache/Test/Functional/MustacheSpecTest.php
@@ -23,6 +23,7 @@ class Mustache_Test_Functional_MustacheSpecTest extends Mustache_Test_SpecTestCa
      */
     public function testSpecInitialized()
     {
+        $this->expectNotToPerformAssertions();
         if (!file_exists(dirname(__FILE__) . '/../../../../vendor/spec/specs/')) {
             $this->markTestSkipped('Mustache spec submodule not initialized: run "git submodule update --init"');
         }

--- a/test/Mustache/Test/Functional/NestedPartialIndentTest.php
+++ b/test/Mustache/Test/Functional/NestedPartialIndentTest.php
@@ -9,11 +9,13 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group functional
  * @group partials
  */
-class Mustache_Test_Functional_NestedPartialIndentTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Functional_NestedPartialIndentTest extends TestCase
 {
     /**
      * @dataProvider partialsAndStuff

--- a/test/Mustache/Test/Functional/ObjectSectionTest.php
+++ b/test/Mustache/Test/Functional/ObjectSectionTest.php
@@ -9,15 +9,17 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group sections
  * @group functional
  */
-class Mustache_Test_Functional_ObjectSectionTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Functional_ObjectSectionTest extends TestCase
 {
     private $mustache;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->mustache = new Mustache_Engine();
     }

--- a/test/Mustache/Test/Functional/StrictVariablesTest.php
+++ b/test/Mustache/Test/Functional/StrictVariablesTest.php
@@ -9,15 +9,17 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group lambdas
  * @group functional
  */
-class Mustache_Test_Functional_StrictVariablesTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Functional_StrictVariablesTest extends TestCase
 {
     private $mustache;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->mustache = new Mustache_Engine(array('strict_variables' => true));
     }
@@ -58,7 +60,6 @@ class Mustache_Test_Functional_StrictVariablesTest extends PHPUnit_Framework_Tes
 
     /**
      * @dataProvider unknownVariableThrowsExceptionProvider
-     * @expectedException Mustache_Exception_UnknownVariableException
      */
     public function testUnknownVariableThrowsException($template)
     {
@@ -69,6 +70,7 @@ class Mustache_Test_Functional_StrictVariablesTest extends PHPUnit_Framework_Tes
         );
 
         $tpl = $this->mustache->loadTemplate($template);
+        $this->expectException(Mustache_Exception_UnknownVariableException::class);
         $tpl->render($context);
     }
 

--- a/test/Mustache/Test/FunctionalTestCase.php
+++ b/test/Mustache/Test/FunctionalTestCase.php
@@ -9,11 +9,13 @@
  * file that was distributed with this source code.
  */
 
-abstract class Mustache_Test_FunctionalTestCase extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class Mustache_Test_FunctionalTestCase extends TestCase
 {
     protected static $tempDir;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         self::$tempDir = sys_get_temp_dir() . '/mustache_test';
         if (file_exists(self::$tempDir)) {

--- a/test/Mustache/Test/HelperCollectionTest.php
+++ b/test/Mustache/Test/HelperCollectionTest.php
@@ -9,7 +9,9 @@
  * file that was distributed with this source code.
  */
 
-class Mustache_Test_HelperCollectionTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Mustache_Test_HelperCollectionTest extends TestCase
 {
     public function testConstructor()
     {
@@ -96,7 +98,9 @@ class Mustache_Test_HelperCollectionTest extends PHPUnit_Framework_TestCase
     public function testHelperCollectionIsntAfraidToThrowExceptions($helpers = array(), $actions = array(), $exception = null)
     {
         if ($exception) {
-            $this->setExpectedException($exception);
+            $this->expectException($exception);
+        } else {
+            $this->expectNotToPerformAssertions();
         }
 
         $helpers = new Mustache_HelperCollection($helpers);

--- a/test/Mustache/Test/Loader/ArrayLoaderTest.php
+++ b/test/Mustache/Test/Loader/ArrayLoaderTest.php
@@ -9,10 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group unit
  */
-class Mustache_Test_Loader_ArrayLoaderTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Loader_ArrayLoaderTest extends TestCase
 {
     public function testConstructor()
     {
@@ -41,12 +43,10 @@ class Mustache_Test_Loader_ArrayLoaderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('BAZ', $loader->load('baz'));
     }
 
-    /**
-     * @expectedException Mustache_Exception_UnknownTemplateException
-     */
     public function testMissingTemplatesThrowExceptions()
     {
         $loader = new Mustache_Loader_ArrayLoader();
+        $this->expectException(Mustache_Exception_UnknownTemplateException::class);
         $loader->load('not_a_real_template');
     }
 }

--- a/test/Mustache/Test/Loader/CascadingLoaderTest.php
+++ b/test/Mustache/Test/Loader/CascadingLoaderTest.php
@@ -9,10 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group unit
  */
-class Mustache_Test_Loader_CascadingLoaderTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Loader_CascadingLoaderTest extends TestCase
 {
     public function testLoadTemplates()
     {
@@ -25,9 +27,6 @@ class Mustache_Test_Loader_CascadingLoaderTest extends PHPUnit_Framework_TestCas
         $this->assertEquals('{{#bar}}BAR{{/bar}}', $loader->load('bar'));
     }
 
-    /**
-     * @expectedException Mustache_Exception_UnknownTemplateException
-     */
     public function testMissingTemplatesThrowExceptions()
     {
         $loader = new Mustache_Loader_CascadingLoader(array(
@@ -35,6 +34,7 @@ class Mustache_Test_Loader_CascadingLoaderTest extends PHPUnit_Framework_TestCas
             new Mustache_Loader_ArrayLoader(array('bar' => '{{#bar}}BAR{{/bar}}')),
         ));
 
+        $this->expectException(Mustache_Exception_UnknownTemplateException::class);
         $loader->load('not_a_real_template');
     }
 }

--- a/test/Mustache/Test/Loader/FilesystemLoaderTest.php
+++ b/test/Mustache/Test/Loader/FilesystemLoaderTest.php
@@ -9,10 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group unit
  */
-class Mustache_Test_Loader_FilesystemLoaderTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Loader_FilesystemLoaderTest extends TestCase
 {
     public function testConstructor()
     {
@@ -59,22 +61,18 @@ class Mustache_Test_Loader_FilesystemLoaderTest extends PHPUnit_Framework_TestCa
         $this->assertEquals('beta contents', $loader->load('beta.ms'));
     }
 
-    /**
-     * @expectedException Mustache_Exception_RuntimeException
-     */
     public function testMissingBaseDirThrowsException()
     {
+        $this->expectException(Mustache_Exception_RuntimeException::class);
         new Mustache_Loader_FilesystemLoader(dirname(__FILE__) . '/not_a_directory');
     }
 
-    /**
-     * @expectedException Mustache_Exception_UnknownTemplateException
-     */
     public function testMissingTemplateThrowsException()
     {
         $baseDir = realpath(dirname(__FILE__) . '/../../../fixtures/templates');
         $loader = new Mustache_Loader_FilesystemLoader($baseDir);
 
+        $this->expectException(Mustache_Exception_UnknownTemplateException::class);
         $loader->load('fake');
     }
 }

--- a/test/Mustache/Test/Loader/InlineLoaderTest.php
+++ b/test/Mustache/Test/Loader/InlineLoaderTest.php
@@ -9,10 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group unit
  */
-class Mustache_Test_Loader_InlineLoaderTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Loader_InlineLoaderTest extends TestCase
 {
     public function testLoadTemplates()
     {
@@ -21,28 +23,22 @@ class Mustache_Test_Loader_InlineLoaderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('{{#bar}}BAR{{/bar}}', $loader->load('bar'));
     }
 
-    /**
-     * @expectedException Mustache_Exception_UnknownTemplateException
-     */
     public function testMissingTemplatesThrowExceptions()
     {
         $loader = new Mustache_Loader_InlineLoader(__FILE__, __COMPILER_HALT_OFFSET__);
+        $this->expectException(Mustache_Exception_UnknownTemplateException::class);
         $loader->load('not_a_real_template');
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testInvalidOffsetThrowsException()
     {
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         new Mustache_Loader_InlineLoader(__FILE__, 'notanumber');
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testInvalidFileThrowsException()
     {
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         new Mustache_Loader_InlineLoader('notarealfile', __COMPILER_HALT_OFFSET__);
     }
 }

--- a/test/Mustache/Test/Loader/ProductionFilesystemLoaderTest.php
+++ b/test/Mustache/Test/Loader/ProductionFilesystemLoaderTest.php
@@ -9,10 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group unit
  */
-class Mustache_Test_Loader_ProductionFilesystemLoaderTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Loader_ProductionFilesystemLoaderTest extends TestCase
 {
     public function testConstructor()
     {
@@ -61,22 +63,18 @@ class Mustache_Test_Loader_ProductionFilesystemLoaderTest extends PHPUnit_Framew
         $this->assertEquals('beta contents', $loader->load('beta.ms')->getSource());
     }
 
-    /**
-     * @expectedException Mustache_Exception_RuntimeException
-     */
     public function testMissingBaseDirThrowsException()
     {
+        $this->expectException(Mustache_Exception_RuntimeException::class);
         new Mustache_Loader_ProductionFilesystemLoader(dirname(__FILE__) . '/not_a_directory');
     }
 
-    /**
-     * @expectedException Mustache_Exception_UnknownTemplateException
-     */
     public function testMissingTemplateThrowsException()
     {
         $baseDir = realpath(dirname(__FILE__) . '/../../../fixtures/templates');
         $loader = new Mustache_Loader_ProductionFilesystemLoader($baseDir);
 
+        $this->expectException(Mustache_Exception_UnknownTemplateException::class);
         $loader->load('fake');
     }
 

--- a/test/Mustache/Test/Loader/StringLoaderTest.php
+++ b/test/Mustache/Test/Loader/StringLoaderTest.php
@@ -9,10 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group unit
  */
-class Mustache_Test_Loader_StringLoaderTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Loader_StringLoaderTest extends TestCase
 {
     public function testLoadTemplates()
     {

--- a/test/Mustache/Test/Logger/AbstractLoggerTest.php
+++ b/test/Mustache/Test/Logger/AbstractLoggerTest.php
@@ -9,10 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group unit
  */
-class Mustache_Test_Logger_AbstractLoggerTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Logger_AbstractLoggerTest extends TestCase
 {
     public function testEverything()
     {

--- a/test/Mustache/Test/Logger/StreamLoggerTest.php
+++ b/test/Mustache/Test/Logger/StreamLoggerTest.php
@@ -9,10 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group unit
  */
-class Mustache_Test_Logger_StreamLoggerTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Logger_StreamLoggerTest extends TestCase
 {
     /**
      * @dataProvider acceptsStreamData
@@ -36,15 +38,13 @@ class Mustache_Test_Logger_StreamLoggerTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException Mustache_Exception_LogicException
-     */
     public function testPrematurelyClosedStreamThrowsException()
     {
         $stream = tmpfile();
         $logger = new Mustache_Logger_StreamLogger($stream);
         fclose($stream);
 
+        $this->expectException(Mustache_Exception_LogicException::class);
         $logger->log(Mustache_Logger::CRITICAL, 'message');
     }
 
@@ -61,7 +61,7 @@ class Mustache_Test_Logger_StreamLoggerTest extends PHPUnit_Framework_TestCase
         $result = fread($stream, 1024);
 
         if ($shouldLog) {
-            $this->assertContains('logged', $result);
+            $this->assertStringContainsString('logged', $result);
         } else {
             $this->assertEmpty($result);
         }
@@ -189,21 +189,17 @@ class Mustache_Test_Logger_StreamLoggerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals("WARNING: log this\n", $result);
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testThrowsInvalidArgumentExceptionWhenSettingUnknownLevels()
     {
         $logger = new Mustache_Logger_StreamLogger(tmpfile());
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         $logger->setLevel('bacon');
     }
 
-    /**
-     * @expectedException Mustache_Exception_InvalidArgumentException
-     */
     public function testThrowsInvalidArgumentExceptionWhenLoggingUnknownLevels()
     {
         $logger = new Mustache_Logger_StreamLogger(tmpfile());
+        $this->expectException(Mustache_Exception_InvalidArgumentException::class);
         $logger->log('bacon', 'CODE BACON ERROR!');
     }
 }

--- a/test/Mustache/Test/ParserTest.php
+++ b/test/Mustache/Test/ParserTest.php
@@ -9,10 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group unit
  */
-class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_ParserTest extends TestCase
 {
     /**
      * @dataProvider getTokenSets
@@ -317,11 +319,11 @@ class Mustache_Test_ParserTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider getBadParseTrees
-     * @expectedException Mustache_Exception_SyntaxException
      */
     public function testParserThrowsExceptions($tokens)
     {
         $parser = new Mustache_Parser();
+        $this->expectException(Mustache_Exception_SyntaxException::class);
         $parser->parse($tokens);
     }
 

--- a/test/Mustache/Test/Source/FilesystemSourceTest.php
+++ b/test/Mustache/Test/Source/FilesystemSourceTest.php
@@ -9,17 +9,17 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group unit
  */
-class Mustache_Test_Source_FilesystemSourceTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_Source_FilesystemSourceTest extends TestCase
 {
-    /**
-     * @expectedException RuntimeException
-     */
     public function testMissingTemplateThrowsException()
     {
         $source = new Mustache_Source_FilesystemSource(dirname(__FILE__) . '/not_a_file.mustache', array('mtime'));
+        $this->expectException(RuntimeException::class);
         $source->getKey();
     }
 }

--- a/test/Mustache/Test/SpecTestCase.php
+++ b/test/Mustache/Test/SpecTestCase.php
@@ -9,11 +9,13 @@
  * file that was distributed with this source code.
  */
 
-abstract class Mustache_Test_SpecTestCase extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class Mustache_Test_SpecTestCase extends TestCase
 {
     protected static $mustache;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass() : void
     {
         self::$mustache = new Mustache_Engine();
     }

--- a/test/Mustache/Test/TemplateTest.php
+++ b/test/Mustache/Test/TemplateTest.php
@@ -9,10 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group unit
  */
-class Mustache_Test_TemplateTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_TemplateTest extends TestCase
 {
     public function testConstructor()
     {

--- a/test/Mustache/Test/TokenizerTest.php
+++ b/test/Mustache/Test/TokenizerTest.php
@@ -9,10 +9,12 @@
  * file that was distributed with this source code.
  */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @group unit
  */
-class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
+class Mustache_Test_TokenizerTest extends TestCase
 {
     /**
      * @dataProvider getTokens
@@ -23,25 +25,21 @@ class Mustache_Test_TokenizerTest extends PHPUnit_Framework_TestCase
         $this->assertSame($expected, $tokenizer->scan($text, $delimiters));
     }
 
-    /**
-     * @expectedException Mustache_Exception_SyntaxException
-     */
     public function testUnevenBracesThrowExceptions()
     {
         $tokenizer = new Mustache_Tokenizer();
 
         $text = '{{{ name }}';
+        $this->expectException(Mustache_Exception_SyntaxException::class);
         $tokenizer->scan($text, null);
     }
 
-    /**
-     * @expectedException Mustache_Exception_SyntaxException
-     */
     public function testUnevenBracesWithCustomDelimiterThrowExceptions()
     {
         $tokenizer = new Mustache_Tokenizer();
 
         $text = '<%{ name %>';
+        $this->expectException(Mustache_Exception_SyntaxException::class);
         $tokenizer->scan($text, '<% %>');
     }
 


### PR DESCRIPTION
No more warnings/deprecations when running the test suite with PHP 7.4.

friendsofphp/php-cs-fixer has been removed due to a dependency conflict
(and the update is not straightforward). We could switch to squizlabs/php_codesniffer
if needed.