### PR TITLE
Improve Tokenizer::scan performance by 98.2%.

### DIFF
--- a/src/Mustache/Tokenizer.php
+++ b/src/Mustache/Tokenizer.php
@@ -72,9 +72,13 @@ class Mustache_Tokenizer
     private $tokens;
     private $seenTag;
     private $line;
+
     private $otag;
-    private $ctag;
+    private $otagChar;
     private $otagLen;
+
+    private $ctag;
+    private $ctagChar;
     private $ctagLen;
 
     /**
@@ -110,12 +114,13 @@ class Mustache_Tokenizer
         for ($i = 0; $i < $len; $i++) {
             switch ($this->state) {
                 case self::IN_TEXT:
-                    if ($this->tagChange($this->otag, $this->otagLen, $text, $i)) {
+                    $char = $text[$i];
+                    // Test whether it's time to change tags.
+                    if ($char === $this->otagChar && substr($text, $i, $this->otagLen) === $this->otag) {
                         $i--;
                         $this->flushBuffer();
                         $this->state = self::IN_TAG_TYPE;
                     } else {
-                        $char = $text[$i];
                         $this->buffer .= $char;
                         if ($char === "\n") {
                             $this->flushBuffer();
@@ -151,7 +156,9 @@ class Mustache_Tokenizer
                     break;
 
                 default:
-                    if ($this->tagChange($this->ctag, $this->ctagLen, $text, $i)) {
+                    $char = $text[$i];
+                    // Test whether it's time to change tags.
+                    if ($char === $this->ctagChar && substr($text, $i, $this->ctagLen) === $this->ctag) {
                         $token = array(
                             self::TYPE  => $this->tagType,
                             self::NAME  => trim($this->buffer),
@@ -196,7 +203,7 @@ class Mustache_Tokenizer
                         $this->state = self::IN_TEXT;
                         $this->tokens[] = $token;
                     } else {
-                        $this->buffer .= $text[$i];
+                        $this->buffer .= $char;
                     }
                     break;
             }
@@ -219,16 +226,20 @@ class Mustache_Tokenizer
      */
     private function reset()
     {
-        $this->state   = self::IN_TEXT;
-        $this->tagType = null;
-        $this->buffer  = '';
-        $this->tokens  = array();
-        $this->seenTag = false;
-        $this->line    = 0;
-        $this->otag    = '{{';
-        $this->ctag    = '}}';
-        $this->otagLen = 2;
-        $this->ctagLen = 2;
+        $this->state    = self::IN_TEXT;
+        $this->tagType  = null;
+        $this->buffer   = '';
+        $this->tokens   = array();
+        $this->seenTag  = false;
+        $this->line     = 0;
+
+        $this->otag     = '{{';
+        $this->otagChar = '{';
+        $this->otagLen  = 2;
+
+        $this->ctag     = '}}';
+        $this->ctagChar = '}';
+        $this->ctagLen  = 2;
     }
 
     /**
@@ -277,11 +288,19 @@ class Mustache_Tokenizer
      */
     private function setDelimiters($delimiters)
     {
-        list($otag, $ctag) = explode(' ', $delimiters);
-        $this->otag = $otag;
-        $this->ctag = $ctag;
-        $this->otagLen = strlen($otag);
-        $this->ctagLen = strlen($ctag);
+        if (!preg_match('/^\s*(\S+)\s+(\S+)\s*$/', $delimiters, $matches)) {
+            throw new Mustache_Exception_InvalidArgumentException(sprintf('Invalid delimiters: %s', $delimiters));
+        }
+
+        list($_, $otag, $ctag) = $matches;
+
+        $this->otag     = $otag;
+        $this->otagChar = $otag[0];
+        $this->otagLen  = strlen($otag);
+
+        $this->ctag     = $ctag;
+        $this->ctagChar = $ctag[0];
+        $this->ctagLen  = strlen($ctag);
     }
 
     /**
@@ -308,20 +327,5 @@ class Mustache_Tokenizer
         ));
 
         return $end + $this->ctagLen - 1;
-    }
-
-    /**
-     * Test whether it's time to change tags.
-     *
-     * @param string $tag    Current tag name
-     * @param int    $tagLen Current tag name length
-     * @param string $text   Mustache template source
-     * @param int    $index  Current tokenizer index
-     *
-     * @return bool True if this is a closing section tag
-     */
-    private function tagChange($tag, $tagLen, $text, $index)
-    {
-        return substr($text, $index, $tagLen) === $tag;
     }
 }


### PR DESCRIPTION
- Checking the first character of the opening and closing tags is >90% faster than baseline for my test case.
- Inlining the `tagChange` method is 18% faster than baseline.
- Together they yield a 98.2% wall clock time improvement!